### PR TITLE
Feat/#29 implement status codes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,7 @@ BasedOnStyle: Google
 # Base
 IndentWidth: 4
 UseTab: Never
-ColumnLimit: "80"
+ColumnLimit: "120"
 MaxEmptyLinesToKeep: "1"
 BreakBeforeBraces: Allman
 

--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,7 @@ BasedOnStyle: Google
 # Base
 IndentWidth: 4
 UseTab: Never
-ColumnLimit: "120"
+ColumnLimit: "160"
 MaxEmptyLinesToKeep: "1"
 BreakBeforeBraces: Allman
 

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@
 # tester
 logs/
 unexpected_response.txt
+
+# log
+access.log

--- a/default.conf
+++ b/default.conf
@@ -6,7 +6,7 @@ server {
 	error_page 404 /404.html;
 	error_page 500 /500.html;
 	client_max_body_size 10M;
-	keepalive_timeout 5;
+	keepalive_timeout 10;
 
 	location / {
 		root /var/www/html;

--- a/src/global/config/Config.cpp
+++ b/src/global/config/Config.cpp
@@ -81,7 +81,13 @@ void Config::parseLocation(std::ifstream& file, ServerConfig& serverConfig, cons
 
 		// key에 따라 설정 값 파싱
 		if (key == "root")
+        {
 			iss >> locationConfig.root;
+            if (locationConfig.root[locationConfig.root.size() - 1] == ';')
+            {
+                locationConfig.root.pop_back();
+            }
+        }
 		else if (key == "index")
 			iss >> locationConfig.index;
 		else if (key == "allow_methods") {

--- a/src/global/config/Config.cpp
+++ b/src/global/config/Config.cpp
@@ -89,7 +89,13 @@ void Config::parseLocation(std::ifstream& file, ServerConfig& serverConfig, cons
             }
         }
 		else if (key == "index")
-			iss >> locationConfig.index;
+        {
+            iss >> locationConfig.index;
+            if (locationConfig.index[locationConfig.index.size() - 1] == ';')
+            {
+                locationConfig.index.pop_back();
+            }
+        }
 		else if (key == "allow_methods") {
 			std::string method;
 			while (iss >> method)

--- a/src/global/exception/HTTPException.cpp
+++ b/src/global/exception/HTTPException.cpp
@@ -1,18 +1,13 @@
 #include "HTTPException.hpp"
 
-HTTPException::HTTPException(int statusCode, const std::string& reasonPhrase)
+HTTPException::HTTPException(const int statusCode)
 : mStatusCode(statusCode)
-, mReasonPhrase(reasonPhrase)
 {
 }
 HTTPException::~HTTPException() _NOEXCEPT
 {
 }
-const std::string HTTPException::getStatusCode() const
+int HTTPException::getStatusCode() const
 {
-    return std::to_string(mStatusCode);
-}
-const std::string& HTTPException::getReasonPhrase() const
-{
-    return mReasonPhrase;
+    return mStatusCode;
 }

--- a/src/global/exception/HTTPException.hpp
+++ b/src/global/exception/HTTPException.hpp
@@ -4,6 +4,10 @@
 #include <exception>
 #include <string>
 
+// https://www.rfc-editor.org/rfc/rfc9110.html#name-status-codes
+// https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
+
 enum eInformational
 {
     CONTINUE = 100,
@@ -84,13 +88,11 @@ class HTTPException : public std::exception
 {
 private:
     int mStatusCode;
-    std::string mReasonPhrase;
 
 public:
-    HTTPException(int statusCode, const std::string& reasonPhrase);
+    HTTPException(const int statusCode);
     virtual ~HTTPException() _NOEXCEPT;
-    const std::string getStatusCode() const;
-    const std::string& getReasonPhrase() const;
+    int getStatusCode() const;
 };
 
 #endif

--- a/src/httpMessage/ResponseMessage.cpp
+++ b/src/httpMessage/ResponseMessage.cpp
@@ -15,7 +15,17 @@ void ResponseMessage::setStatusLine(const std::string& httpVersion, const std::s
     mStatusLine.setStatusCode(statusCode);
     mStatusLine.setReasonPhrase(reasonPhrase);
 }
+void ResponseMessage::setStatusLine(const std::string& httpVersion, const int statusCode, const std::string& reasonPhrase)
+{
+    mStatusLine.setHTTPVersion(httpVersion);
+    mStatusLine.setStatusCode(statusCode);
+    mStatusLine.setReasonPhrase(reasonPhrase);
+}
 void ResponseMessage::addResponseHeaderField(const std::string& key, const std::string& value)
+{
+    mResponseHeaderFields.addField(key, value);
+}
+void ResponseMessage::addResponseHeaderField(const std::string& key, int value)
 {
     mResponseHeaderFields.addField(key, value);
 }
@@ -23,13 +33,15 @@ void ResponseMessage::addMessageBody(const std::string& body)
 {
     mMessageBody.addBody(body);
 }
-std::string ResponseMessage::toString(void)
+std::string ResponseMessage::toString(void) const
 {
-    mResponseHeaderFields.addField("Content-Length", std::to_string(mMessageBody.size()));
-    mResponseHeaderFields.addField("Server", "webserv");
     std::ostringstream oss;
     oss << mStatusLine.toString() << mResponseHeaderFields.toString() << "\r\n" << mMessageBody.toString();
     return oss.str();
+}
+size_t ResponseMessage::getMessageBodySize() const
+{
+    return mMessageBody.size();
 }
 void ResponseMessage::clearMessageBody()
 {

--- a/src/httpMessage/ResponseMessage.cpp
+++ b/src/httpMessage/ResponseMessage.cpp
@@ -26,6 +26,7 @@ void ResponseMessage::addMessageBody(const std::string& body)
 std::string ResponseMessage::toString(void)
 {
     mResponseHeaderFields.addField("Content-Length", std::to_string(mMessageBody.size()));
+    mResponseHeaderFields.addField("Server", "webserv");
     std::ostringstream oss;
     oss << mStatusLine.toString() << mResponseHeaderFields.toString() << "\r\n" << mMessageBody.toString();
     return oss.str();

--- a/src/httpMessage/ResponseMessage.cpp
+++ b/src/httpMessage/ResponseMessage.cpp
@@ -31,3 +31,7 @@ std::string ResponseMessage::toString(void)
     oss << mStatusLine.toString() << mResponseHeaderFields.toString() << "\r\n" << mMessageBody.toString();
     return oss.str();
 }
+void ResponseMessage::clearMessageBody()
+{
+    mMessageBody.clear();
+}

--- a/src/httpMessage/ResponseMessage.hpp
+++ b/src/httpMessage/ResponseMessage.hpp
@@ -19,9 +19,12 @@ public:
     ResponseMessage();
     ~ResponseMessage();
     void setStatusLine(const std::string& httpVersion, const std::string& statusCode, const std::string& reasonPhrase);
+    void setStatusLine(const std::string& httpVersion, const int statusCode, const std::string& reasonPhrase);
     void addResponseHeaderField(const std::string& key, const std::string& value);
+    void addResponseHeaderField(const std::string& key, int value);
     void addMessageBody(const std::string& body);
-    std::string toString(void);
+    std::string toString(void) const;
+    size_t getMessageBodySize() const;
     void clearMessageBody();
 };
 

--- a/src/httpMessage/ResponseMessage.hpp
+++ b/src/httpMessage/ResponseMessage.hpp
@@ -22,6 +22,7 @@ public:
     void addResponseHeaderField(const std::string& key, const std::string& value);
     void addMessageBody(const std::string& body);
     std::string toString(void);
+    void clearMessageBody();
 };
 
 #endif

--- a/src/httpMessage/headerFields/HeaderFields.cpp
+++ b/src/httpMessage/headerFields/HeaderFields.cpp
@@ -25,6 +25,10 @@ void HeaderFields::addField(const std::string& key, const std::string& value)
 {
     mFields[key] = value;
 }
+void HeaderFields::addField(const std::string& key, int value)
+{
+    mFields[key] = std::to_string(value);
+}
 bool HeaderFields::hasField(const std::string& key) const
 {
     return mFields.find(key) != mFields.end();

--- a/src/httpMessage/headerFields/HeaderFields.hpp
+++ b/src/httpMessage/headerFields/HeaderFields.hpp
@@ -17,6 +17,7 @@ public:
     ~HeaderFields();
     void parseHeaderFields(std::istringstream& headerFields);
     void addField(const std::string& key, const std::string& value);
+    void addField(const std::string& key, int value);
     bool hasField(const std::string& key) const;
     std::string getField(const std::string& key) const;
     std::string toString() const;

--- a/src/httpMessage/messageBody/MessageBody.cpp
+++ b/src/httpMessage/messageBody/MessageBody.cpp
@@ -27,3 +27,7 @@ size_t MessageBody::size() const
 {
     return mContent.size();
 }
+void MessageBody::clear()
+{
+    mContent.clear();
+}

--- a/src/httpMessage/messageBody/MessageBody.hpp
+++ b/src/httpMessage/messageBody/MessageBody.hpp
@@ -17,6 +17,7 @@ public:
     void addBody(const std::string& body);
     const std::string& toString() const;
     size_t size() const;
+    void clear();
 };
 
 #endif

--- a/src/httpMessage/startLine/RequestLine.cpp
+++ b/src/httpMessage/startLine/RequestLine.cpp
@@ -13,7 +13,7 @@ RequestLine::~RequestLine()
 void RequestLine::parseRequestLine(const std::string& requestLine)
 {
     // TODO: parse request line
-    // request-line = <method> SP <request-URL> SP <HTTP-version> CRLF
+    // request-line = <method> SP <request-target> SP <HTTP-version> CRLF
 
     std::istringstream iss(requestLine);
     if (iss >> mMethod >> mRequestTarget >> mHTTPVersion)

--- a/src/httpMessage/startLine/RequestLine.cpp
+++ b/src/httpMessage/startLine/RequestLine.cpp
@@ -3,7 +3,7 @@
 
 RequestLine::RequestLine()
 : mMethod("")
-, mRequestURL("")
+, mRequestTarget("")
 , mHTTPVersion("")
 {
 }
@@ -16,7 +16,7 @@ void RequestLine::parseRequestLine(const std::string& requestLine)
     // request-line = <method> SP <request-URL> SP <HTTP-version> CRLF
 
     std::istringstream iss(requestLine);
-    if (iss >> mMethod >> mRequestURL >> mHTTPVersion)
+    if (iss >> mMethod >> mRequestTarget >> mHTTPVersion)
     {
         // success
     }
@@ -24,7 +24,7 @@ void RequestLine::parseRequestLine(const std::string& requestLine)
     {
         // fail
         mMethod = "";
-        mRequestURL = "";
+        mRequestTarget = "";
         mHTTPVersion = "";
         throw std::exception();
     }
@@ -34,9 +34,9 @@ std::string RequestLine::getMethod(void) const
 {
     return mMethod;
 }
-std::string RequestLine::getRequestURL(void) const
+std::string RequestLine::getRequestTarget(void) const
 {
-    return mRequestURL;
+    return mRequestTarget;
 }
 std::string RequestLine::getHTTPVersion(void) const
 {

--- a/src/httpMessage/startLine/RequestLine.hpp
+++ b/src/httpMessage/startLine/RequestLine.hpp
@@ -7,7 +7,7 @@ class RequestLine
 {
 private:
     std::string mMethod;
-    std::string mRequestURL;
+    std::string mRequestTarget;
     std::string mHTTPVersion;
     RequestLine(const RequestLine& rhs);
     RequestLine& operator=(const RequestLine& rhs);
@@ -17,7 +17,7 @@ public:
     ~RequestLine();
     void parseRequestLine(const std::string& requestLine);
     std::string getMethod(void) const;
-    std::string getRequestURL(void) const;
+    std::string getRequestTarget(void) const;
     std::string getHTTPVersion(void) const;
 };
 

--- a/src/httpMessage/startLine/StatusLine.cpp
+++ b/src/httpMessage/startLine/StatusLine.cpp
@@ -29,6 +29,10 @@ void StatusLine::setStatusCode(const std::string& statusCode)
 {
     mStatusCode = statusCode;
 }
+void StatusLine::setStatusCode(const int statusCode)
+{
+    mStatusCode = std::to_string(statusCode);
+}
 void StatusLine::setReasonPhrase(const std::string& reasonPhrase)
 {
     mReasonPhrase = reasonPhrase;

--- a/src/httpMessage/startLine/StatusLine.hpp
+++ b/src/httpMessage/startLine/StatusLine.hpp
@@ -20,6 +20,7 @@ public:
     const std::string& getReasonPhrase() const;
     void setHTTPVersion(const std::string& httpVersion);
     void setStatusCode(const std::string& statusCode);
+    void setStatusCode(const int statusCode);
     void setReasonPhrase(const std::string& reasonPhrase);
     const std::string toString() const;
 };

--- a/src/requestHandler/RequestHandler.cpp
+++ b/src/requestHandler/RequestHandler.cpp
@@ -86,6 +86,14 @@ void RequestHandler::addContentType(ResponseMessage& res, const std::string& pat
     {
         res.addResponseHeaderField("Content-Type", "text/html");
     }
+    else if (ext == "css")
+    {
+        res.addResponseHeaderField("Content-Type", "text/css");
+    }
+    else if (ext == "js")
+    {
+        res.addResponseHeaderField("Content-Type", "text/javascript");
+    }
     else if (ext == "jpg" || ext == "jpeg")
     {
         res.addResponseHeaderField("Content-Type", "image/jpeg");
@@ -118,13 +126,8 @@ void RequestHandler::getRequest(const RequestMessage& req, ResponseMessage& res,
 }
 void RequestHandler::headRequest(const RequestMessage& req, ResponseMessage& res, const ServerConfig& serverConfig, const std::string& path)
 {
-    (void)req;
-    (void)res;
-    (void)serverConfig;
-    (void)path;
-    res.setStatusLine(req.getRequestLine().getHTTPVersion(), std::to_string(OK), "OK");
-    res.addResponseHeaderField("Content-Type", "text/html");
-    res.addMessageBody("<html><body><h1>HEAD Request</h1></body></html>");
+    getRequest(req, res, serverConfig, path);
+    res.clearMessageBody();
 }
 void RequestHandler::postRequest(const RequestMessage& req, ResponseMessage& res, const ServerConfig& serverConfig, const std::string& path)
 {

--- a/src/requestHandler/RequestHandler.cpp
+++ b/src/requestHandler/RequestHandler.cpp
@@ -3,27 +3,30 @@
 void RequestHandler::verifyRequestLine(const RequestLine& reqLine)
 {
     const std::string method = reqLine.getMethod();
-    const std::string req_url = reqLine.getRequestURL();
+    const std::string req_tg = reqLine.getRequestTarget();
     const std::string ver = reqLine.getHTTPVersion();
     if (method != "GET" && method != "POST" && method != "DELETE" && method != "PUT")
     {
-        throw HTTPException(METHOD_NOT_ALLOWED, "Method Not Allowed");
+        throw HTTPException(METHOD_NOT_ALLOWED);
     }
     if (ver != "HTTP/1.1")
     {
-        throw HTTPException(HTTP_VERSION_NOT_SUPPORTED, "HTTP Version Not Supported");
+        throw HTTPException(HTTP_VERSION_NOT_SUPPORTED);
     }
-    if (req_url[0] != '/')
+    if (req_tg[0] != '/')
     {
-        throw HTTPException(NOT_FOUND, "Not Found");
+        throw HTTPException(NOT_FOUND);
+    }
+    if (req_tg.size() >= 8200) // nginx max uri length
+    {
+        throw HTTPException(URI_TOO_LONG);
     }
 }
-void RequestHandler::verifyRequestHeaderFields(
-    const HeaderFields& reqHeaderFields)
+void RequestHandler::verifyRequestHeaderFields(const HeaderFields& reqHeaderFields)
 {
     if (reqHeaderFields.hasField("Host") == false)
     {
-        throw HTTPException(BAD_REQUEST, "Bad Request");
+        throw HTTPException(BAD_REQUEST);
     }
 }
 void RequestHandler::verifyRequest(const RequestMessage& req, const ServerConfig& serverConfig)
@@ -42,35 +45,58 @@ void RequestHandler::verifyRequest(const RequestMessage& req, const ServerConfig
 }
 void RequestHandler::handleRequest(const RequestMessage& req, ResponseMessage& res, const ServerConfig& serverConfig)
 {
-    // std::map<std::string, LocationConfig>::const_iterator it =
-    // serverConfig.locations.find(request.getPath()); if (it !=
-    // serverConfig.locations.end()) { 	response.setStatusCode(404, "OK");
-    // 	response.setHeader("Content-Type", "text/plain");
-    // 	response.setBody("Not Found");
-
-    // 	return ;
-    // }
-
-    // const LocationConfig& locConfig = it->second;
-
-    // if (std::find(locConfig.allow_methods.begin(),
-    // locConfig.allow_methods.end(), request.getMethod()) ==
-    // locConfig.allow_methods.end()) { 	response.setStatusCode(405, "test");
-    // 	response.setHeader("Content-Type", "text/plain");
-    // 	response.setBody("Method Not Allowed");
-
-    // 	return ;
-    // }
-    (void)req;
     (void)serverConfig;
 
-    res.setStatusLine(
-        req.getRequestLine().getHTTPVersion(), std::to_string(OK), "OK");
+    res.setStatusLine(req.getRequestLine().getHTTPVersion(), std::to_string(OK), "OK");
     res.addResponseHeaderField("Content-Type", "text/html");
     res.addMessageBody("<html><body><h1>Request Received</h1></body></html>");
 }
-
 void RequestHandler::handleException(const HTTPException& e, ResponseMessage& res)
 {
-    res.setStatusLine("HTTP/1.1", e.getStatusCode(), e.getReasonPhrase());
+    if (e.getStatusCode() == BAD_REQUEST)
+    {
+        badRequest(res);
+    }
+    else if (e.getStatusCode() == NOT_FOUND)
+    {
+        notFound(res);
+    }
+    else if (e.getStatusCode() == METHOD_NOT_ALLOWED)
+    {
+        methodNotAllowed(res);
+    }
+    else if (e.getStatusCode() == HTTP_VERSION_NOT_SUPPORTED)
+    {
+        httpVersionNotSupported(res);
+    }
+    else if (e.getStatusCode() == URI_TOO_LONG)
+    {
+        res.setStatusLine("HTTP/1.1", std::to_string(URI_TOO_LONG), "Request-URI Too Long");
+        res.addResponseHeaderField("Content-Type", "text/html");
+        res.addMessageBody("<html><head><title>414 Request-URI Too Long</title></head><body><h1>414 Request-URI Too Long</h1></body></html>");
+    }
+}
+void RequestHandler::badRequest(ResponseMessage& res)
+{
+    res.setStatusLine("HTTP/1.1", std::to_string(BAD_REQUEST), "Bad Request");
+    res.addResponseHeaderField("Content-Type", "text/html");
+    res.addMessageBody("<html><head><title>400 Bad Request</title></head><body><h1>400 Bad Request</h1></body></html>");
+}
+void RequestHandler::notFound(ResponseMessage& res)
+{
+    res.setStatusLine("HTTP/1.1", std::to_string(NOT_FOUND), "Not Found");
+    res.addResponseHeaderField("Content-Type", "text/html");
+    res.addMessageBody("<html><head><title>404 Not Found</title></head><body><h1>404 Not Found</h1></body></html>");
+}
+void RequestHandler::methodNotAllowed(ResponseMessage& res)
+{
+    res.setStatusLine("HTTP/1.1", std::to_string(METHOD_NOT_ALLOWED), "Method Not Allowed");
+    res.addResponseHeaderField("Content-Type", "text/html");
+    res.addMessageBody("<html><head><title>405 Method Not Allowed</title></head><body><h1>405 Method Not Allowed</h1></body></html>");
+}
+void RequestHandler::httpVersionNotSupported(ResponseMessage& res)
+{
+    res.setStatusLine("HTTP/1.1", std::to_string(HTTP_VERSION_NOT_SUPPORTED), "HTTP Version Not Supported");
+    res.addResponseHeaderField("Content-Type", "text/html");
+    res.addMessageBody("<html><head><title>505 HTTP Version Not Supported</title></head><body><h1>505 HTTP Version Not Supported</h1></body></html>");
 }

--- a/src/requestHandler/RequestHandler.cpp
+++ b/src/requestHandler/RequestHandler.cpp
@@ -105,7 +105,6 @@ void RequestHandler::getRequest(const RequestMessage& req, ResponseMessage& res,
     std::ifstream file(path);
     if (file.is_open() == false)
     {
-        // NOTE: 파일 권한이 없을 경우, 403 Forbidden인지 확인 필요
         throw HTTPException(FORBIDDEN);
     }
     res.setStatusLine(req.getRequestLine().getHTTPVersion(), std::to_string(OK), "OK");

--- a/src/requestHandler/RequestHandler.hpp
+++ b/src/requestHandler/RequestHandler.hpp
@@ -1,18 +1,23 @@
 #pragma once
 
 #include <string>
+#include "Config.hpp"
+#include "HTTPException.hpp"
 #include "RequestMessage.hpp"
 #include "ResponseMessage.hpp"
-#include "HTTPException.hpp"
-#include "Config.hpp"
 
-class RequestHandler {
+class RequestHandler
+{
 private:
     void verifyRequestLine(const RequestLine& reqLine);
     void verifyRequestHeaderFields(const HeaderFields& reqHeaderFields);
+    void badRequest(ResponseMessage& res);
+    void notFound(ResponseMessage& res);
+    void methodNotAllowed(ResponseMessage& res);
+    void httpVersionNotSupported(ResponseMessage& res);
 
 public:
     void verifyRequest(const RequestMessage& req, const ServerConfig& serverConfig);
-	void handleRequest(const RequestMessage& req, ResponseMessage& res, const ServerConfig& serverConfig);
+    void handleRequest(const RequestMessage& req, ResponseMessage& res, const ServerConfig& serverConfig);
     void handleException(const HTTPException& e, ResponseMessage& res);
 };

--- a/src/requestHandler/RequestHandler.hpp
+++ b/src/requestHandler/RequestHandler.hpp
@@ -26,6 +26,7 @@ private:
     void methodNotAllowed(ResponseMessage& res);
     void httpVersionNotSupported(ResponseMessage& res);
     void uriTooLong(ResponseMessage& res);
+    void forbidden(ResponseMessage& res);
 
 public:
     void verifyRequest(const RequestMessage& req, const ServerConfig& serverConfig);

--- a/src/requestHandler/RequestHandler.hpp
+++ b/src/requestHandler/RequestHandler.hpp
@@ -9,12 +9,22 @@
 class RequestHandler
 {
 private:
+    // Request
     void verifyRequestLine(const RequestLine& reqLine);
     void verifyRequestHeaderFields(const HeaderFields& reqHeaderFields);
+
+    // Response (Success)
+    void getRequest(const RequestMessage& req, ResponseMessage& res, const ServerConfig& serverConfig);
+    void headRequest(const RequestMessage& req, ResponseMessage& res, const ServerConfig& serverConfig);
+    void postRequest(const RequestMessage& req, ResponseMessage& res, const ServerConfig& serverConfig);
+    void deleteRequest(const RequestMessage& req, ResponseMessage& res, const ServerConfig& serverConfig);
+
+    // Response (Exception)
     void badRequest(ResponseMessage& res);
     void notFound(ResponseMessage& res);
     void methodNotAllowed(ResponseMessage& res);
     void httpVersionNotSupported(ResponseMessage& res);
+    void uriTooLong(ResponseMessage& res);
 
 public:
     void verifyRequest(const RequestMessage& req, const ServerConfig& serverConfig);

--- a/src/requestHandler/RequestHandler.hpp
+++ b/src/requestHandler/RequestHandler.hpp
@@ -14,10 +14,11 @@ private:
     void verifyRequestHeaderFields(const HeaderFields& reqHeaderFields);
 
     // Response (Success)
-    void getRequest(const RequestMessage& req, ResponseMessage& res, const ServerConfig& serverConfig);
-    void headRequest(const RequestMessage& req, ResponseMessage& res, const ServerConfig& serverConfig);
-    void postRequest(const RequestMessage& req, ResponseMessage& res, const ServerConfig& serverConfig);
-    void deleteRequest(const RequestMessage& req, ResponseMessage& res, const ServerConfig& serverConfig);
+    void getRequest(const RequestMessage& req, ResponseMessage& res, const ServerConfig& serverConfig, const std::string& path);
+    void headRequest(const RequestMessage& req, ResponseMessage& res, const ServerConfig& serverConfig, const std::string& path);
+    void postRequest(const RequestMessage& req, ResponseMessage& res, const ServerConfig& serverConfig, const std::string& path);
+    void deleteRequest(const RequestMessage& req, ResponseMessage& res, const ServerConfig& serverConfig, const std::string& path);
+    void addContentType(ResponseMessage& res, const std::string& path);
 
     // Response (Exception)
     void badRequest(ResponseMessage& res);

--- a/src/server/Server.hpp
+++ b/src/server/Server.hpp
@@ -37,6 +37,7 @@ private:
 	void acceptClient(int serverSocket);
 	void handleClientReadEvent(struct kevent& event);
 
+    void logHTTPMessage(int socket, ResponseMessage& res, const std::string& reqData);
 	void sendResponse(int socket, ResponseMessage& res);
 	void closeConnection(int socket);
 

--- a/test/nginxRequestTester/nginxContainer/Dockerfile
+++ b/test/nginxRequestTester/nginxContainer/Dockerfile
@@ -2,11 +2,13 @@ FROM nginx:1.27.0-alpine
 
 # entrypoint and services
 COPY entrypoint.sh .
-COPY www/ /usr/lib/cgi-bin/
+COPY www/index.py /usr/lib/cgi-bin/index.py
+COPY www/forbidden.html /usr/share/nginx/html/forbidden.html
 
 RUN apk add --no-cache python3 py3-pip fcgiwrap && \
     mkdir -p /var/log/nginx && \
     chmod 755 /usr/lib/cgi-bin/index.py && \
-    chmod 755 entrypoint.sh
+    chmod 755 entrypoint.sh && \
+    chmod 000 /usr/share/nginx/html/forbidden.html
 
 ENTRYPOINT ["sh", "./entrypoint.sh"]

--- a/test/nginxRequestTester/nginxContainer/www/forbidden.html
+++ b/test/nginxRequestTester/nginxContainer/www/forbidden.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>This is forbidden page</title>
+</head>
+<body>
+    <h1>Forbidden</h1>
+</body>
+</html>

--- a/test/nginxRequestTester/tester.sh
+++ b/test/nginxRequestTester/tester.sh
@@ -15,6 +15,10 @@ requests=(
 Host: seunan:8081
 
 " 400
+"GET /forbidden.html HTTP/1.1
+Host: localhost:8080
+
+" 403
 )
 
 # ----------------------------------------------

--- a/test/nginxRequestTester/tester.sh
+++ b/test/nginxRequestTester/tester.sh
@@ -9,7 +9,7 @@ requests=(
 "GET / HTTP/1.1\nHost: localhost:8080\n\n\n" 200
 "GET / HTTP/1.1" 0
 "GET / HTTP/1.1
-" 400
+" 0
 "GET /cgi-bin/ HTTP/1.1\nHost:  localhost:8080\nAccept: */*\n\n" 200
 "GET / HTTP/1.1
 Host: seunan:8081


### PR DESCRIPTION
## 주요 구현 사항

- HTTP msg 로그 추가
- Config location 블록 root, index 뒤 ';' 제거
- Get method 구현
- Head method 구현
- 매개변수로 전달하기 위해 사용하는 `std::to_string` 함수 때문에 코드가 길어져서 함수 오버로딩을 통해 형변환 없이 매개변수로 전달하게끔 함

## 관련있는 이슈 번호

- #21
- #22
- #29

## 리뷰어 참고 사항

- Config 파일 파싱 후 문법 올바른지 체크 필요해 보임
- Config 파일에서 MIME 타입 파싱하여 Config 객체에 저장 필요
- 가끔 세그 폴트가 나니 `make mem` 으로 컴파일해서 세그폴트 원인 확인하기
