### PR TITLE
fix: Fix server not disconnecting client sockets when they send EOF

### DIFF
--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -191,8 +191,11 @@ void Server::acceptClient(int serverSocket)
 
 // 클라이언트 요청 처리
 void Server::handleClientReadEvent(struct kevent& event) {
-    // if (event.flags & EV_EOF)
-    //     return;
+    if (event.flags & EV_EOF)
+    {
+        closeConnection(event.ident);
+        return;
+    }
 
     int socket = event.ident;
 


### PR DESCRIPTION
## 주요 구현 사항

- 서버에서 클라이언트 소켓이 EOF를 보낼 때 커넥션을 끊는 로직 추가
- `echo -e "request msg.." | nc <ip> <port>` 에서 nc 명령어가 종료하지 않고 계속 유지되고 서버에서 리시브 에러가 나는 것을 보고 수정함

## 관련있는 이슈 번호

- #

## 리뷰어 참고 사항

- 
