### PR TITLE
[Fix] Allow Methods 파싱에서 마지막 메서드를 빼고 저장하는 버그 수정

### DIFF
--- a/src/global/config/Config.cpp
+++ b/src/global/config/Config.cpp
@@ -304,15 +304,15 @@ void Config::parseAllowMethods(LocationConfig& locationConfig, std::string& valu
     std::string method;
     while (getline(iss, method, ' '))
     {
-        if (iss.eof())
-        {
-            break;
-        }
         if (method != "GET" && method != "HEAD" && method != "POST" && method != "DELETE")
         {
             throw ConfigException(INVALID_CONFIG_FILE);
         }
         locationConfig.allow_methods.push_back(method);
+        if (iss.eof())
+        {
+            break;
+        }
     }
 }
 


### PR DESCRIPTION
## 주요 구현 사항

- Allow Methods 파싱에서 마지막 메서드를 빼고 저장하는 버그 수정

## 관련있는 이슈 번호

- #

## 리뷰어 참고 사항

- 기존에 allow_methods GET; 이라면 GET을 저장하지 못 했고,
- allow_methods GET POST; 이라면 POST를 저장하지 못 했습니다.
