### PR TITLE
refactor: Separate LocationConfig and ServerConfig objects in the Con…

### DIFF
--- a/conf/default.conf
+++ b/conf/default.conf
@@ -26,7 +26,9 @@ server {
     }
 
 
-    location /cgi-bin/ {
+    location .py {
+        root www/cgi-bin/;
+        index index.py;
         cgi_interpreter /usr/bin/python;
     }
 

--- a/src/config/Config.hpp
+++ b/src/config/Config.hpp
@@ -1,61 +1,8 @@
 #ifndef CONFIG_HPP
 #define CONFIG_HPP
 
-#include <map>
-#include <string>
+#include "ServerConfig.hpp"
 #include <vector>
-
-#define LOCATION first
-#define CONFIG second
-
-const size_t DEFAULT_TIMEOUT = 60;
-const size_t MAX_TIMEOUT = 600;
-const size_t DEFAULT_MAX_BODY_SIZE = 1024;  // 1KB
-const int MAX_PORT_NUM = 65535;
-
-struct LocationConfig
-{
-    std::string root;
-    std::string index;
-    std::map<std::string, bool> allow_methods;
-    bool directory_listing;
-    std::string redirect;
-    std::string cgi_interpreter;
-    std::string prefix;
-
-    LocationConfig()
-    : root()
-    , index()
-    , allow_methods()
-    , directory_listing(false)
-    , redirect()
-    , cgi_interpreter()
-    , prefix()
-    {
-    }
-};
-
-struct ServerConfig
-{
-    std::string host;
-    int port;
-    std::string root;
-    std::string index;
-    size_t client_max_body_size;
-    std::map<size_t, std::string> error_pages;
-    std::map<std::string, LocationConfig> locations;
-
-    ServerConfig()
-    : host()
-    , port(-1)
-    , root()
-    , index()
-    , client_max_body_size(DEFAULT_MAX_BODY_SIZE)
-    , error_pages()
-    , locations()
-    {
-    }
-};
 
 class Config
 {
@@ -63,39 +10,20 @@ private:
     size_t keepalive_timeout;
     std::vector<ServerConfig> serverConfigs;
 
-    static const size_t implementMethodsSize;
-    static const std::string implementMethods[];
-
     void parse(const std::string& configFilePath);
-    // Parse Config
     void parseKeepAliveTimeout(std::string& line);
     void parseServer(std::ifstream& file);
-    // Parse ServerConfig
-    void parseHost(ServerConfig& serverConfig, std::string& value);
-    void parsePort(ServerConfig& serverConfig, std::string& value);
-    void parseRoot(ServerConfig& serverConfig, std::string& value);
-    void parseIndex(ServerConfig& serverConfig, std::string& value);
-    void parseClientMaxBodySize(ServerConfig& serverConfig, std::string& value);
-    void parseErrorPage(ServerConfig& serverConfig, std::string& value);
-    void parseLocation(std::ifstream& file, ServerConfig& serverConfig, std::string& locationPath);
-    // Parse LocationConfig
-    void parseRoot(LocationConfig& locationConfig, std::string& value);
-    void parseIndex(LocationConfig& locationConfig, std::string& value);
-    void parseAllowMethods(LocationConfig& locationConfig, std::string& value);
-    void parseDirectoryListing(LocationConfig& locationConfig, std::string& value);
-    void parseRedirect(LocationConfig& locationConfig, std::string& value);
-    void parseCGI(LocationConfig& locationConfig, std::string& value);
-    // Check Validity
-    bool isValidValue(std::string& value);
-    bool isValidLocationPath(std::string& locationPath, const ServerConfig& serverConfig);
-
     void verifyConfig(void);
     void makePrefix(const std::string& loc, LocationConfig& locConf);
 
     const ServerConfig& getDefaultServerConfig() const;
 
+    Config(const Config& rhs);
+    Config& operator=(const Config& rhs);
+
 public:
     Config(const std::string& configFilePath);
+    ~Config();
     const std::vector<ServerConfig>& getServerConfigs() const;
     const ServerConfig& getServerConfigByHost(std::string host) const;
     size_t getKeepAliveTime() const;

--- a/src/config/locationConfig/LocationConfig.cpp
+++ b/src/config/locationConfig/LocationConfig.cpp
@@ -1,0 +1,97 @@
+#include "LocationConfig.hpp"
+#include <sstream>
+#include "ConfigException.hpp"
+#include "parse.hpp"
+
+const size_t LocationConfig::implementMethodsSize = 4;
+const std::string LocationConfig::implementMethods[implementMethodsSize] = {"GET", "HEAD", "POST", "DELETE"};
+
+LocationConfig::LocationConfig()
+: root()
+, index()
+, allow_methods()
+, directory_listing(false)
+, redirect()
+, cgi_interpreter()
+, prefix()
+{
+}
+LocationConfig::~LocationConfig()
+{
+}
+LocationConfig::LocationConfig(const LocationConfig& rhs)
+: root(rhs.root)
+, index(rhs.index)
+, allow_methods(rhs.allow_methods)
+, directory_listing(rhs.directory_listing)
+, redirect(rhs.redirect)
+, cgi_interpreter(rhs.cgi_interpreter)
+, prefix(rhs.prefix)
+{
+}
+LocationConfig& LocationConfig::operator=(const LocationConfig& rhs)
+{
+    if (this == &rhs)
+        return *this;
+    root = rhs.root;
+    index = rhs.index;
+    allow_methods = rhs.allow_methods;
+    directory_listing = rhs.directory_listing;
+    redirect = rhs.redirect;
+    cgi_interpreter = rhs.cgi_interpreter;
+    prefix = rhs.prefix;
+    return *this;
+}
+void LocationConfig::parseRoot(std::string& value)
+{
+    if (!isValidValue(value))
+        throw ConfigException(INVALID_LOCATION_CONFIG);
+    root = value;
+}
+void LocationConfig::parseIndex(std::string& value)
+{
+    if (!isValidValue(value))
+        throw ConfigException(INVALID_LOCATION_CONFIG);
+    index = value;
+}
+void LocationConfig::parseAllowMethods(std::string& value)
+{
+    if (value.back() != ';')
+        throw ConfigException(INVALID_LOCATION_CONFIG);
+    value.pop_back();
+    std::istringstream iss(value);
+    std::string method;
+    while (iss >> method)
+    {
+        if (allow_methods[method] == true)
+            throw ConfigException(INVALID_LOCATION_CONFIG);
+        if (std::find(implementMethods, implementMethods + implementMethodsSize, method) == implementMethods + implementMethodsSize)
+            throw ConfigException(INVALID_LOCATION_CONFIG);
+        allow_methods[method] = true;
+    }
+    if (allow_methods.empty())
+        throw ConfigException(INVALID_LOCATION_CONFIG);
+}
+void LocationConfig::parseDirectoryListing(std::string& value)
+{
+    if (!isValidValue(value))
+        throw ConfigException(INVALID_LOCATION_CONFIG);
+    if (value == "on")
+        directory_listing = true;
+    else if (value == "off")
+        directory_listing = false;
+    else
+        throw ConfigException(INVALID_LOCATION_CONFIG);
+}
+void LocationConfig::parseRedirect(std::string& value)
+{
+    if (!isValidValue(value))
+        throw ConfigException(INVALID_LOCATION_CONFIG);
+    redirect = value;
+}
+void LocationConfig::parseCGI(std::string& value)
+{
+    if (!isValidValue(value))
+        throw ConfigException(INVALID_LOCATION_CONFIG);
+    cgi_interpreter = value;
+}

--- a/src/config/locationConfig/LocationConfig.hpp
+++ b/src/config/locationConfig/LocationConfig.hpp
@@ -1,0 +1,41 @@
+#ifndef LOCATION_CONFIG_HPP
+#define LOCATION_CONFIG_HPP
+
+#include <map>
+#include <string>
+
+#define LOCATION first
+#define CONFIG   second
+
+const size_t DEFAULT_TIMEOUT = 60;
+const size_t MAX_TIMEOUT = 600;
+const size_t DEFAULT_MAX_BODY_SIZE = 1024;  // 1KB
+const int MAX_PORT_NUM = 65535;
+
+class LocationConfig
+{
+public:
+    std::string root;
+    std::string index;
+    std::map<std::string, bool> allow_methods;
+    bool directory_listing;
+    std::string redirect;
+    std::string cgi_interpreter;
+    std::string prefix;
+
+    static const size_t implementMethodsSize;
+    static const std::string implementMethods[];
+
+    LocationConfig();
+    ~LocationConfig();
+    LocationConfig(const LocationConfig& rhs);
+    LocationConfig& operator=(const LocationConfig& rhs);
+    void parseRoot(std::string& value);
+    void parseIndex(std::string& value);
+    void parseAllowMethods(std::string& value);
+    void parseDirectoryListing(std::string& value);
+    void parseRedirect(std::string& value);
+    void parseCGI(std::string& value);
+};
+
+#endif

--- a/src/config/serverConfig/ServerConfig.cpp
+++ b/src/config/serverConfig/ServerConfig.cpp
@@ -1,0 +1,172 @@
+#include "ServerConfig.hpp"
+#include <sstream>
+#include "ConfigException.hpp"
+#include "parse.hpp"
+
+ServerConfig::ServerConfig()
+: host()
+, port(-1)
+, root()
+, index()
+, client_max_body_size(DEFAULT_MAX_BODY_SIZE)
+, error_pages()
+, locations()
+{
+}
+ServerConfig::~ServerConfig()
+{
+}
+ServerConfig::ServerConfig(const ServerConfig& rhs)
+: host(rhs.host)
+, port(rhs.port)
+, root(rhs.root)
+, index(rhs.index)
+, client_max_body_size(rhs.client_max_body_size)
+, error_pages(rhs.error_pages)
+, locations(rhs.locations)
+{
+}
+ServerConfig& ServerConfig::operator=(const ServerConfig& rhs)
+{
+    if (this == &rhs)
+        return *this;
+    host = rhs.host;
+    port = rhs.port;
+    root = rhs.root;
+    index = rhs.index;
+    client_max_body_size = rhs.client_max_body_size;
+    error_pages = rhs.error_pages;
+    locations = rhs.locations;
+    return *this;
+}
+void ServerConfig::parseLocation(std::ifstream& file, std::string& locationPath)
+{
+    LocationConfig locationConfig;
+    std::string line;
+    std::map<std::string, bool> duplicateCheck;
+
+    while (std::getline(file, line) && line.find("}") == std::string::npos)
+    {
+        if (line.empty())
+            continue;
+        std::istringstream iss(line);
+        std::string key, value;
+        iss >> key;
+        getline(iss, value);
+        if (duplicateCheck[key])
+            throw ConfigException(INVALID_LOCATION_CONFIG);
+        try
+        {
+            if (key == "root") locationConfig.parseRoot(value);
+            else if (key == "index") locationConfig.parseIndex(value);
+            else if (key == "allow_methods") locationConfig.parseAllowMethods(value);
+            else if (key == "directory_listing") locationConfig.parseDirectoryListing(value);
+            else if (key == "redirect") locationConfig.parseRedirect(value);
+            else if (key == "cgi_interpreter") locationConfig.parseCGI(value);
+            else if (key == "location")
+            {
+                if (!isValidLocationPath(value))
+                {
+                    throw ConfigException(INVALID_LOCATION_CONFIG);
+                }
+                if (value.find(locationPath) != 0)
+                {
+                    throw ConfigException(INVALID_LOCATION_CONFIG);
+                }
+                parseLocation(file, value);
+            }
+            else
+                throw ConfigException(INVALID_LOCATION_CONFIG);
+        }
+        catch (const ConfigException& e)
+        {
+            throw e;
+        }
+        duplicateCheck[key] = true;
+    }
+    locations[locationPath] = locationConfig;
+}
+void ServerConfig::parseHost(std::string& value)
+{
+    if (!isValidValue(value))
+        throw ConfigException(INVALID_SERVER_CONFIG);
+    host = value;
+}
+void ServerConfig::parsePort(std::string& value)
+{
+    if (!isValidValue(value) || !isDigitStr(value))
+        throw ConfigException(INVALID_SERVER_CONFIG);
+    port = atoi(value.c_str());
+    if (port > MAX_PORT_NUM || port == 0)
+    {
+        throw ConfigException(INVALID_SERVER_CONFIG);
+    }
+}
+void ServerConfig::parseRoot(std::string& value)
+{
+    if (!isValidValue(value))
+        throw ConfigException(INVALID_SERVER_CONFIG);
+    root = value;
+}
+void ServerConfig::parseIndex(std::string& value)
+{
+    if (!isValidValue(value))
+        throw ConfigException(INVALID_SERVER_CONFIG);
+    index = value;
+}
+void ServerConfig::parseClientMaxBodySize(std::string& value)
+{
+    if (!isValidValue(value) || !isDigitStr(value))
+        throw ConfigException(INVALID_SERVER_CONFIG);
+    client_max_body_size = atoi(value.c_str());
+    if (client_max_body_size == 0)
+        throw ConfigException(INVALID_SERVER_CONFIG);
+}
+void ServerConfig::parseErrorPage(std::string& value)
+{
+    trim(value);
+    std::istringstream iss(value);
+    std::vector<int> statuses;
+    std::string prefix;
+    while (getline(iss, prefix, ' '))
+    {
+        if (iss.eof())
+            break;
+        if (!isDigitStr(prefix) || prefix.empty())
+            throw ConfigException(INVALID_SERVER_CONFIG);
+        size_t status = atoi(prefix.c_str());
+        if (status < 100 || status > 599)
+            throw ConfigException(INVALID_SERVER_CONFIG);
+        statuses.push_back(status);
+    }
+    if (!isValidValue(prefix))
+        throw ConfigException(INVALID_SERVER_CONFIG);
+    for (std::vector<int>::iterator it = statuses.begin(); it != statuses.end(); ++it)
+        error_pages[*it] = prefix;
+}
+bool ServerConfig::isValidLocationPath(std::string& locationPath)
+{
+    if (locationPath.back() != '{' || locationPath.find("//") != std::string::npos)
+    {
+        return false;
+    }
+    locationPath.pop_back();
+    trim(locationPath);
+    if (locationPath.empty())
+    {
+        return false;
+    }
+    if (find(locationPath.begin(), locationPath.end(), ' ') != locationPath.end())
+    {
+        return false;
+    }
+    if (locationPath.front() != '/' && locationPath.front() != '.')
+    {
+        return false;
+    }
+    if (locations.find(locationPath) != locations.end())
+    {
+        return false;
+    }
+    return true;
+}

--- a/src/config/serverConfig/ServerConfig.hpp
+++ b/src/config/serverConfig/ServerConfig.hpp
@@ -1,0 +1,33 @@
+#ifndef SERVER_CONFIG_HPP
+#define SERVER_CONFIG_HPP
+
+#include <fstream>
+#include "LocationConfig.hpp"
+
+class ServerConfig
+{
+public:
+    std::string host;
+    int port;
+    std::string root;
+    std::string index;
+    size_t client_max_body_size;
+    std::map<size_t, std::string> error_pages;
+    std::map<std::string, LocationConfig> locations;
+
+    ServerConfig();
+    ~ServerConfig();
+    ServerConfig(const ServerConfig& rhs);
+    ServerConfig& operator=(const ServerConfig& rhs);
+    void parseHost(std::string& value);
+    void parsePort(std::string& value);
+    void parseRoot(std::string& value);
+    void parseIndex(std::string& value);
+    void parseClientMaxBodySize(std::string& value);
+    void parseErrorPage(std::string& value);
+    void parseLocation(std::ifstream& file, std::string& locationPath);
+
+    bool isValidLocationPath(std::string& locationPath);
+};
+
+#endif

--- a/src/global/parse/parse.cpp
+++ b/src/global/parse/parse.cpp
@@ -1,0 +1,56 @@
+#include "parse.hpp"
+
+bool isWhitespace(char c)
+{
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+}
+void trim(std::string &str)
+{
+    size_t start = 0;
+    size_t end = str.size();
+    while (start < end && isWhitespace(str[start]))
+    {
+        ++start;
+    }
+    while (end > start && isWhitespace(str[end - 1]))
+    {
+        --end;
+    }
+    if (start == end)
+    {
+        str.clear();
+    }
+    else
+    {
+        str = str.substr(start, end - start);
+    }
+}
+bool isDigitStr(const std::string &str)
+{
+    for (size_t i = 0; i < str.size(); ++i)
+    {
+        if (!isdigit(str[i]))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+bool isValidValue(std::string& value)
+{
+    trim(value);
+    if (value.back() != ';')
+    {
+        return false;
+    }
+    value.pop_back();
+    if (value.empty())
+    {
+        return false;
+    }
+    if (std::find(value.begin(), value.end(), ' ') != value.end())
+    {
+        return false;
+    }
+    return true;
+}

--- a/src/global/parse/parse.hpp
+++ b/src/global/parse/parse.hpp
@@ -1,0 +1,11 @@
+#ifndef PARSE_HPP
+#define PARSE_HPP
+
+#include <string>
+
+bool isWhitespace(char c);
+void trim(std::string &str);
+bool isDigitStr(const std::string &str);
+bool isValidValue(std::string& value);
+
+#endif


### PR DESCRIPTION
## 주요 구현 사항

- Config 파일이 너무 커져서 ServerConfig와 LocationConfig 객체를 따로 분리
- 기존 cgi location 블록을 폴더가 아닌 `.<확장자>` 블록에서 식별

## 관련있는 이슈 번호

- #

## 리뷰어 참고 사항

-
