### PR TITLE
feat: Add parsing capabilities for http message

### DIFF
--- a/src/httpMessage/RequestMessage.hpp
+++ b/src/httpMessage/RequestMessage.hpp
@@ -6,29 +6,32 @@
 #include "MessageBody.hpp"
 #include "StartLine.hpp"
 
+// nginx max uri length
+const int MAX_URI_LENGTH = 8200;
+
 class RequestMessage
 {
 private:
     StartLine mRequestLine;
     HeaderFields mRequestHeaderFields;
     MessageBody mMessageBody;
-    void parseRequestMessage(const std::string& request);
     void parseRequestLine(std::istringstream& reqStream);
     void parseRequestHeaderFields(std::istringstream& reqStream);
-    void parseMessageBody(std::istringstream& reqStream);
+    void verifyRequestLine(void) const;
+    void verifyRequestHeaderFields(void) const;
+
     RequestMessage(const RequestMessage& rhs);
     RequestMessage& operator=(const RequestMessage& rhs);
-    void verifyRequest(void);
-    void verifyRequestLine(void);
-    void verifyRequestHeaderFields(void);
 
 public:
     RequestMessage();
-    RequestMessage(const std::string& request);
     ~RequestMessage();
     const StartLine& getRequestLine() const;
     const HeaderFields& getRequestHeaderFields() const;
     const MessageBody& getMessageBody() const;
+    void parseRequestHeader(const std::string& request);
+    void addMessageBody(const std::string& body);
+    void verifyRequestMessage(void) const;
     std::string toString(void) const;
 };
 

--- a/src/httpMessage/ResponseMessage.cpp
+++ b/src/httpMessage/ResponseMessage.cpp
@@ -1,4 +1,5 @@
 #include "ResponseMessage.hpp"
+#include "HttpException.hpp"
 
 ResponseMessage::ResponseMessage()
 : mStatusLine()
@@ -8,6 +9,43 @@ ResponseMessage::ResponseMessage()
 }
 ResponseMessage::~ResponseMessage()
 {
+}
+void ResponseMessage::parseResponseHeader(const std::string& response)
+{
+    std::istringstream resStream(response);
+    try
+    {
+        parseStatusLine(resStream);
+        parseResponseHeaderFields(resStream);
+    }
+    catch (const HttpException& e)
+    {
+        throw e;
+    }
+}
+void ResponseMessage::parseStatusLine(std::istringstream& resStream)
+{
+    std::string requestLine;
+    std::getline(resStream, requestLine);
+    try
+    {
+        mStatusLine.parseRequestLine(requestLine);
+    }
+    catch (const HttpException& e)
+    {
+        throw e;
+    }
+}
+void ResponseMessage::parseResponseHeaderFields(std::istringstream& resStream)
+{
+    try
+    {
+        mResponseHeaderFields.parseHeaderFields(resStream);
+    }
+    catch (const HttpException& e)
+    {
+        throw e;
+    }
 }
 void ResponseMessage::setStatusLine(const std::string& httpVersion, const std::string& statusCode, const std::string& reasonPhrase)
 {
@@ -35,9 +73,7 @@ void ResponseMessage::addMessageBody(const std::string& body)
 }
 std::string ResponseMessage::toString(void) const
 {
-    std::ostringstream oss;
-    oss << mStatusLine.toStatusLine() << mResponseHeaderFields.toString() << "\r\n" << mMessageBody.toString();
-    return oss.str();
+    return mStatusLine.toStatusLine() + mResponseHeaderFields.toString() + mMessageBody.toString();
 }
 size_t ResponseMessage::getMessageBodySize() const
 {

--- a/src/httpMessage/ResponseMessage.hpp
+++ b/src/httpMessage/ResponseMessage.hpp
@@ -12,23 +12,25 @@ private:
     StartLine mStatusLine;
     HeaderFields mResponseHeaderFields;
     MessageBody mMessageBody;
+    void addSemanticHeaderFields();
+    void parseStatusLine(std::istringstream& resStream);
+    void parseResponseHeaderFields(std::istringstream& resStream);
+
     ResponseMessage(const ResponseMessage& rhs);
     ResponseMessage& operator=(const ResponseMessage& rhs);
-
-    void addSemanticHeaderFields();
 
 public:
     ResponseMessage();
     ~ResponseMessage();
+    void parseResponseHeader(const std::string& response);
     void setStatusLine(const std::string& httpVersion, const std::string& statusCode, const std::string& reasonPhrase);
     void setStatusLine(const std::string& httpVersion, const int statusCode, const std::string& reasonPhrase);
     void addResponseHeaderField(const std::string& key, const std::string& value);
     void addResponseHeaderField(const std::string& key, const int value);
     void addMessageBody(const std::string& body);
-    std::string toString(void) const;
     size_t getMessageBodySize() const;
     void clearMessageBody();
-
+    std::string toString(void) const;
 
     void setByStatusCode(const int statusCode);
 

--- a/src/httpMessage/headerFields/HeaderFields.cpp
+++ b/src/httpMessage/headerFields/HeaderFields.cpp
@@ -71,5 +71,6 @@ std::string HeaderFields::toString() const
     {
         result += it->KEY + ": " + it->VALUE + "\r\n";
     }
+    result += "\r\n";
     return result;
 }

--- a/src/httpMessage/messageBody/MessageBody.cpp
+++ b/src/httpMessage/messageBody/MessageBody.cpp
@@ -1,20 +1,11 @@
 #include "MessageBody.hpp"
 
 MessageBody::MessageBody()
-: mContent("")
+: mContent()
 {
 }
 MessageBody::~MessageBody()
 {
-}
-void MessageBody::parseMessageBody(std::istringstream& body)
-{
-    std::string line;
-    while (std::getline(body, line))
-    {
-        // TODO: 마지막 줄에 개행이 없을 경우 처리
-        mContent += line + "\n";
-    }
 }
 void MessageBody::addBody(const std::string& body)
 {

--- a/src/httpMessage/messageBody/MessageBody.hpp
+++ b/src/httpMessage/messageBody/MessageBody.hpp
@@ -14,7 +14,6 @@ private:
 public:
     MessageBody();
     ~MessageBody();
-    void parseMessageBody(std::istringstream& body);
     void addBody(const std::string& body);
     const std::string& toString() const;
     size_t size() const;


### PR DESCRIPTION
## 주요 구현 사항

- Response, Request Message에 parse 기능을 보완
    - parseMessage에서 모두 다 파싱하던 것을 parseHeader(Start-Line, Header-Fields), addMessageBody(Message-Body)로 나눔
    - 이로 인해서 Content-Length 확인해서 버퍼에 있는 메시지를 적절히 자를 수 있고 cgi 응답에 대해 파싱이 가능해짐

## 관련있는 이슈 번호

- #

## 리뷰어 참고 사항

-
